### PR TITLE
Fix library loading in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The dynamic system library *K2 basecamp* is an implementation of the [CT-API](do
 | Key       | Value                                    |
 | --------- | ---------------------------------------- |
 | base_url  | URL of the REST endpoint of *K2 peak*.<br/>**Default: http://localhost:8080/k2/ctapi** |
+| timeout   | Timeout in ms for each http request. <br/>**Default: 1000** |
 | log_level | Set the verbosity level for logging. Possible values: Off, Error, Warn, Info, Debug, Trace<br/>**Default: Error** |
 | log_path  | Target folder of the log file.<br/>**Default: Logging to STDOUT** |
 | ctn       | Set card terminal number to use for all requests. *Requires that pn is set!* |

--- a/examples/settings-file/Cargo.toml
+++ b/examples/settings-file/Cargo.toml
@@ -3,6 +3,7 @@ name = "settings-file"
 version = "0.1.1"
 
 [dependencies]
-libloading = "0.4.3"
-rand = "0.4.1"
-test-server = { git = "https://github.com/ChriFo/test-server-rs", tag = "v0.1.0" }
+const-cstr = "0.2.1"
+dlopen = "0.1.3"
+rand = "0.4.2"
+test-server = { git = "https://github.com/ChriFo/test-server-rs", tag = "v0.3.0" }

--- a/examples/use-library/Cargo.toml
+++ b/examples/use-library/Cargo.toml
@@ -3,6 +3,7 @@ name = "use-libray"
 version = "0.1.0"
 
 [dependencies]
-libloading = "0.4.3"
+const-cstr = "0.1"
+dlopen = "0.1.3"
 rand = "0.4.1"
 test-server = { git = "https://github.com/ChriFo/test-server-rs", tag = "v0.1.1" }

--- a/examples/use-library/Cargo.toml
+++ b/examples/use-library/Cargo.toml
@@ -3,7 +3,7 @@ name = "use-libray"
 version = "0.1.0"
 
 [dependencies]
-const-cstr = "0.1"
+const-cstr = "0.2.1"
 dlopen = "0.1.3"
-rand = "0.4.1"
-test-server = { git = "https://github.com/ChriFo/test-server-rs", tag = "v0.1.1" }
+rand = "0.4.2"
+test-server = { git = "https://github.com/ChriFo/test-server-rs", tag = "v0.3.0" }

--- a/src/ctapi/close.rs
+++ b/src/ctapi/close.rs
@@ -57,6 +57,8 @@ mod tests {
 
     #[test]
     fn returns_err_htsi_if_no_server() {
+        env::set_var("K2_BASE_URL", "http://127.0.0.1:65432");
+
         let ctn = rand::random::<u16>();
         let pn = rand::random::<u16>();
 

--- a/src/ctapi/data.rs
+++ b/src/ctapi/data.rs
@@ -152,6 +152,8 @@ mod tests {
 
     #[test]
     fn returns_err_htsi_if_no_server() {
+        env::set_var("K2_BASE_URL", "http://127.0.0.1:65432");
+
         let (commands_ptr, lenc, response_ptr, mut lenr, mut dad, mut sad, ctn, pn) = rand_params();
 
         MAP.lock().insert(ctn, pn);

--- a/src/ctapi/init.rs
+++ b/src/ctapi/init.rs
@@ -56,6 +56,8 @@ mod tests {
 
     #[test]
     fn returns_err_htsi_if_no_server() {
+        env::set_var("K2_BASE_URL", "http://127.0.0.1:65432");
+
         let ctn = rand::random::<u16>();
         let pn = rand::random::<u16>();
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -8,6 +8,7 @@ const CFG_FILE: &str = "libctehxk2";
 
 #[derive(Debug, Deserialize)]
 pub struct Settings {
+    timeout: u64,
     base_url: String,
     log_level: String,
     log_path: Option<String>,
@@ -22,6 +23,7 @@ impl Settings {
         s.set_default("base_url", "http://localhost:8080/k2/ctapi/")
             .unwrap();
         s.set_default("log_level", "Error").unwrap();
+        s.set_default("timeout", 1000).unwrap();
 
         s.merge(File::with_name(CFG_FILE).required(false)).unwrap();
         s.merge(Environment::with_prefix("k2")).unwrap();
@@ -77,6 +79,11 @@ impl Settings {
             }
             None => None,
         }
+    }
+
+    pub fn timeout() -> u64 {
+        let s = Settings::new();
+        s.timeout.clone()
     }
 }
 


### PR DESCRIPTION
Use dlopen crate. Old implementation was broken on mac (sometimes).