### PR TITLE
env-helper

### DIFF
--- a/src/ctapi/data.rs
+++ b/src/ctapi/data.rs
@@ -11,8 +11,7 @@ struct Response {
     sad: u8,
     lenr: u16,
     response: String,
-    #[serde(rename = "responseCode")]
-    status: i8,
+    #[serde(rename = "responseCode")] status: i8,
 }
 
 pub fn data(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,9 +5,9 @@ extern crate futures;
 extern crate hyper;
 #[macro_use]
 extern crate lazy_static;
+extern crate log4rs;
 #[macro_use]
 extern crate log;
-extern crate log4rs;
 #[cfg(test)]
 extern crate rand;
 extern crate serde;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,3 +77,13 @@ pub extern "system" fn CT_close(ctn: u16) -> i8 {
     debug!("Returning {}", status);
     status.into()
 }
+
+pub extern "system" fn env() {
+    println!(
+        "Path used to load config file: {}",
+        std::env::current_dir()
+            .expect("Failed to get current dir!")
+            .to_str()
+            .expect("Failed to create string of path!")
+    );
+}


### PR DESCRIPTION
The config file is sometimes not found.
To get some environment specific information a fourth function is added.